### PR TITLE
Added interface for RowExpression translation in connecters

### DIFF
--- a/presto-expression-translation-toolkit/pom.xml
+++ b/presto-expression-translation-toolkit/pom.xml
@@ -1,0 +1,275 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.facebook.presto</groupId>
+        <artifactId>presto-root</artifactId>
+        <version>0.227-SNAPSHOT</version>
+    </parent>
+    <artifactId>presto-expression-translation-toolkit</artifactId>
+    <description>Presto - Expression Translation Toolkit</description>
+    <packaging>presto-plugin</packaging>
+
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+        <dep.log4j.version>2.9.1</dep.log4j.version>
+        <dep.elasticsearch.version>6.0.0</dep.elasticsearch.version>
+        <dep.searchguard.version>6.0.1-25.4</dep.searchguard.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-main</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-record-decoder</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>bootstrap</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>concurrent</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>json</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>log</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.floragunn</groupId>
+            <artifactId>search-guard-ssl</artifactId>
+            <version>${dep.searchguard.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.elasticsearch.plugin</groupId>
+                    <artifactId>transport-netty4-client</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.elasticsearch.client</groupId>
+            <artifactId>transport</artifactId>
+            <version>${dep.elasticsearch.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.yaml</groupId>
+                    <artifactId>snakeyaml</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.ow2.asm</groupId>
+                    <artifactId>asm-all</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.ow2.asm</groupId>
+                    <artifactId>asm-commons</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.ow2.asm</groupId>
+                    <artifactId>asm</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.hdrhistogram</groupId>
+                    <artifactId>HdrHistogram</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.elasticsearch</groupId>
+            <artifactId>elasticsearch</artifactId>
+            <version>${dep.elasticsearch.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.yaml</groupId>
+                    <artifactId>snakeyaml</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.ow2.asm</groupId>
+                    <artifactId>asm-all</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.ow2.asm</groupId>
+                    <artifactId>asm-commons</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.ow2.asm</groupId>
+                    <artifactId>asm</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.hdrhistogram</groupId>
+                    <artifactId>HdrHistogram</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.elasticsearch.plugin</groupId>
+            <artifactId>transport-netty4-client</artifactId>
+            <version>${dep.elasticsearch.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>${dep.log4j.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>${dep.log4j.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>log-manager</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- provided -->
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-spi</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>units</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>slice</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- for testing -->
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-main</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-tests</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-tpch</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>http-server</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>node</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift.tpch</groupId>
+            <artifactId>tpch</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/presto-expression-translation-toolkit/src/main/java/com/facebook/presto/expressiontranslationtoolkit/ScalarFromAnnotationsParser.java
+++ b/presto-expression-translation-toolkit/src/main/java/com/facebook/presto/expressiontranslationtoolkit/ScalarFromAnnotationsParser.java
@@ -1,0 +1,187 @@
+package com.facebook.presto.expressiontranslationtoolkit;
+
+import com.facebook.presto.spi.function.FunctionMetadata;
+import com.facebook.presto.spi.function.ScalarFunction;
+import com.facebook.presto.spi.function.ScalarOperator;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.type.TypeSignature;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+import java.lang.annotation.Annotation;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Parameter;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static com.facebook.presto.expressiontranslationtoolkit.ScalarHeader.fromAnnotatedElement;
+import static com.facebook.presto.spi.function.FunctionKind.SCALAR;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class ScalarFromAnnotationsParser
+{
+    private ScalarFromAnnotationsParser()
+    {
+    }
+
+    public static Map<FunctionMetadata, MethodHandle> parseFunctionDefinitions(Class<?> clazz)
+    {
+        ImmutableMap.Builder<FunctionMetadata, MethodHandle> translatorBuilder = ImmutableMap.builder();
+        for (ScalarHeaderAndMethods methods : findScalarsFromSetClass(clazz)) {
+            translatorBuilder.putAll(scalarToFunctionMetadata(methods));
+        }
+
+        return translatorBuilder.build();
+    }
+
+    public static TypeSignature removeTypeParameters(TypeSignature typeSignature)
+    {
+        return new TypeSignature(typeSignature.getBase());
+    }
+
+    public static FunctionMetadata removeTypeParameters(FunctionMetadata metadata)
+    {
+        ImmutableList.Builder<TypeSignature> argumentsBuilder = ImmutableList.builder();
+        for (TypeSignature typeSignature : metadata.getArgumentTypes()) {
+            argumentsBuilder.add(removeTypeParameters(typeSignature));
+        }
+
+        if (metadata.getOperatorType().isPresent()) {
+            return new FunctionMetadata(
+                    metadata.getOperatorType().get(),
+                    argumentsBuilder.build(),
+                    metadata.getReturnType(),
+                    metadata.getFunctionKind(),
+                    metadata.isDeterministic(),
+                    metadata.isCalledOnNullInput());
+        }
+        else {
+            return new FunctionMetadata(
+                    metadata.getName(),
+                    argumentsBuilder.build(),
+                    metadata.getReturnType(),
+                    metadata.getFunctionKind(),
+                    metadata.isDeterministic(),
+                    metadata.isCalledOnNullInput());
+        }
+    }
+
+    private static MethodHandle getMethodHandle(Method method)
+    {
+        try {
+            return MethodHandles.lookup().unreflect(method);
+        }
+        catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static List<ScalarHeaderAndMethods> findScalarsFromSetClass(Class<?> clazz)
+    {
+        ImmutableList.Builder<ScalarHeaderAndMethods> builder = ImmutableList.builder();
+        for (Method method : findPublicMethodsWithAnnotation(clazz, SqlType.class, ScalarFunction.class, ScalarOperator.class)) {
+            boolean annotationCondition = (method.getAnnotation(ScalarFunction.class) != null) || (method.getAnnotation(ScalarOperator.class) != null);
+            checkArgument(annotationCondition, format("Method [%s] annotated with @SqlType is missing @ScalarFunction or @ScalarOperator", method));
+
+            for (ScalarHeader header : fromAnnotatedElement(method)) {
+                builder.add(new ScalarHeaderAndMethods(header, ImmutableSet.of(method)));
+            }
+        }
+        List<ScalarHeaderAndMethods> methods = builder.build();
+        checkArgument(!methods.isEmpty(), "Class [%s] does not have any methods annotated with @ScalarFunction or @ScalarOperator", clazz.getName());
+
+        return methods;
+    }
+
+    private static Map<FunctionMetadata, MethodHandle> scalarToFunctionMetadata(ScalarHeaderAndMethods scalar)
+    {
+        ScalarHeader header = scalar.getHeader();
+
+        ImmutableMap.Builder<FunctionMetadata, MethodHandle> metadataBuilder = ImmutableMap.builder();
+        for (Method method : scalar.getMethods()) {
+            FunctionMetadata metadata = methodToFunctionMetadata(header, method);
+            metadataBuilder.put(removeTypeParameters(metadata), getMethodHandle(method));
+        }
+
+        return metadataBuilder.build();
+    }
+
+    private static FunctionMetadata methodToFunctionMetadata(ScalarHeader header, Method method)
+    {
+        requireNonNull(header, "header is null");
+
+        // return type
+        SqlType annotatedReturnType = method.getAnnotation(SqlType.class);
+        checkArgument(annotatedReturnType != null, format("Method [%s] is missing @SqlType annotation", method));
+        TypeSignature returnType = parseTypeSignature(annotatedReturnType.value(), ImmutableSet.of());
+
+        // argument type
+        ImmutableList.Builder<TypeSignature> argumentTypes = new ImmutableList.Builder<>();
+        for (Parameter parameter : method.getParameters()) {
+            Annotation[] annotations = parameter.getAnnotations();
+
+            SqlType type = Stream.of(annotations)
+                    .filter(SqlType.class::isInstance)
+                    .map(SqlType.class::cast)
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalArgumentException(format("Method [%s] is missing @SqlType annotation for parameter", method)));
+            TypeSignature typeSignature = parseTypeSignature(type.value(), ImmutableSet.of());
+            argumentTypes.add(typeSignature);
+        }
+
+        if (header.getOperatorType().isPresent()) {
+            return new FunctionMetadata(header.getOperatorType().get(), argumentTypes.build(), returnType, SCALAR, header.isDeterministic(), header.isCalledOnNullInput());
+        }
+        else {
+            return new FunctionMetadata(header.getName(), argumentTypes.build(), returnType, SCALAR, header.isDeterministic(), header.isCalledOnNullInput());
+        }
+    }
+
+    @SafeVarargs
+    private static Set<Method> findPublicMethodsWithAnnotation(Class<?> clazz, Class<? extends Annotation>... annotationClasses)
+    {
+        ImmutableSet.Builder<Method> methods = ImmutableSet.builder();
+        for (Method method : clazz.getDeclaredMethods()) {
+            for (Annotation annotation : method.getAnnotations()) {
+                for (Class<?> annotationClass : annotationClasses) {
+                    if (annotationClass.isInstance(annotation)) {
+                        checkArgument(Modifier.isPublic(method.getModifiers()), "Method [%s] annotated with @%s must be public", method, annotationClass.getSimpleName());
+                        methods.add(method);
+                    }
+                }
+            }
+        }
+        return methods.build();
+    }
+
+    private static class ScalarHeaderAndMethods
+    {
+        private final ScalarHeader header;
+        private final Set<Method> methods;
+
+        public ScalarHeaderAndMethods(ScalarHeader header, Set<Method> methods)
+        {
+            this.header = requireNonNull(header, "header is null");
+            this.methods = requireNonNull(methods, "methods are null");
+        }
+
+        public ScalarHeader getHeader()
+        {
+            return header;
+        }
+
+        public Set<Method> getMethods()
+        {
+            return methods;
+        }
+    }
+}

--- a/presto-expression-translation-toolkit/src/main/java/com/facebook/presto/expressiontranslationtoolkit/ScalarHeader.java
+++ b/presto-expression-translation-toolkit/src/main/java/com/facebook/presto/expressiontranslationtoolkit/ScalarHeader.java
@@ -1,0 +1,104 @@
+package com.facebook.presto.expressiontranslationtoolkit;
+
+import com.facebook.presto.spi.function.OperatorType;
+import com.facebook.presto.spi.function.ScalarFunction;
+import com.facebook.presto.spi.function.ScalarOperator;
+import com.facebook.presto.spi.relation.FullyQualifiedName;
+import com.google.common.collect.ImmutableList;
+
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.base.CaseFormat.LOWER_CAMEL;
+import static com.google.common.base.CaseFormat.LOWER_UNDERSCORE;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public class ScalarHeader
+{
+    private final FullyQualifiedName name;
+    private final Optional<OperatorType> operatorType;
+    private final boolean deterministic;
+    private final boolean calledOnNullInput;
+
+    private ScalarHeader(String name, boolean deterministic, boolean calledOnNullInput)
+    {
+        // TODO This is a hack. Engine should provide an API for connectors to overwrite functions. Connector should not hard code the builtin function namespace.
+        this.name = requireNonNull(FullyQualifiedName.of("presto", "default", name));
+        this.operatorType = Optional.empty();
+        this.deterministic = deterministic;
+        this.calledOnNullInput = calledOnNullInput;
+    }
+
+    private ScalarHeader(OperatorType operatorType, boolean deterministic, boolean calledOnNullInput)
+    {
+        this.name = operatorType.getFunctionName();
+        this.operatorType = Optional.of(operatorType);
+        this.deterministic = deterministic;
+        this.calledOnNullInput = calledOnNullInput;
+    }
+
+    private static String annotatedName(AnnotatedElement annotatedElement)
+    {
+        if (annotatedElement instanceof Class<?>) {
+            return ((Class<?>) annotatedElement).getSimpleName();
+        }
+        else if (annotatedElement instanceof Method) {
+            return ((Method) annotatedElement).getName();
+        }
+
+        throw new UnsupportedOperationException("Only Classes and Methods are supported as annotated elements.");
+    }
+
+    private static String camelToSnake(String name)
+    {
+        return LOWER_CAMEL.to(LOWER_UNDERSCORE, name);
+    }
+
+    public static List<ScalarHeader> fromAnnotatedElement(AnnotatedElement annotated)
+    {
+        ScalarFunction scalarFunction = annotated.getAnnotation(ScalarFunction.class);
+        ScalarOperator scalarOperator = annotated.getAnnotation(ScalarOperator.class);
+
+        ImmutableList.Builder<ScalarHeader> builder = ImmutableList.builder();
+
+        if (scalarFunction != null) {
+            String baseName = scalarFunction.value().isEmpty() ? camelToSnake(annotatedName(annotated)) : scalarFunction.value();
+            builder.add(new ScalarHeader(baseName, scalarFunction.deterministic(), scalarFunction.calledOnNullInput()));
+
+            for (String alias : scalarFunction.alias()) {
+                builder.add(new ScalarHeader(alias, scalarFunction.deterministic(), scalarFunction.calledOnNullInput()));
+            }
+        }
+
+        if (scalarOperator != null) {
+            builder.add(new ScalarHeader(scalarOperator.value(), true, scalarOperator.value().isCalledOnNullInput()));
+        }
+
+        List<ScalarHeader> result = builder.build();
+        checkArgument(!result.isEmpty());
+        return result;
+    }
+
+    public FullyQualifiedName getName()
+    {
+        return name;
+    }
+
+    public Optional<OperatorType> getOperatorType()
+    {
+        return operatorType;
+    }
+
+    public boolean isDeterministic()
+    {
+        return deterministic;
+    }
+
+    public boolean isCalledOnNullInput()
+    {
+        return calledOnNullInput;
+    }
+}

--- a/presto-expression-translation-toolkit/src/main/java/com/facebook/presto/expressiontranslationtoolkit/TargetExpression.java
+++ b/presto-expression-translation-toolkit/src/main/java/com/facebook/presto/expressiontranslationtoolkit/TargetExpression.java
@@ -1,0 +1,59 @@
+package com.facebook.presto.expressiontranslationtoolkit;
+
+import com.facebook.presto.spi.relation.RowExpression;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Optional;
+
+public class TargetExpression<T>
+{
+    private RowExpression originalExpression;
+    private List<TargetExpression> params;
+    private Optional<T> translatedExpression;
+
+    public TargetExpression(Optional<T> translatedExpression)
+    {
+        this.translatedExpression = translatedExpression;
+    }
+
+    public static TargetExpression empty()
+    {
+        return new TargetExpression(Optional.empty());
+    }
+
+    public boolean isTranslatedExpressionPresent()
+    {
+        return translatedExpression.isPresent();
+    }
+
+    public RowExpression getOriginalExpression()
+    {
+        return originalExpression;
+    }
+
+    public void setOriginalExpression(RowExpression originalExpression)
+    {
+        this.originalExpression = originalExpression;
+    }
+
+    public List<TargetExpression> getParams()
+    {
+        return ImmutableList.copyOf(params);
+    }
+
+    public void addParam(TargetExpression param)
+    {
+        this.params.add(param);
+    }
+
+    public Optional<T> getTranslatedExpression()
+    {
+        return translatedExpression;
+    }
+
+    public void setTranslatedExpression(Optional<T> translatedExpression)
+    {
+        this.translatedExpression = translatedExpression;
+    }
+}

--- a/presto-expression-translation-toolkit/src/main/java/com/facebook/presto/expressiontranslationtoolkit/translator/AbstractFunctionTranslator.java
+++ b/presto-expression-translation-toolkit/src/main/java/com/facebook/presto/expressiontranslationtoolkit/translator/AbstractFunctionTranslator.java
@@ -1,0 +1,89 @@
+package com.facebook.presto.expressiontranslationtoolkit.translator;
+
+import com.facebook.presto.expressiontranslationtoolkit.TargetExpression;
+import com.facebook.presto.spi.function.FunctionMetadata;
+import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeSignature;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+import java.lang.invoke.MethodHandle;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.facebook.presto.expressiontranslationtoolkit.ScalarFromAnnotationsParser.parseFunctionDefinitions;
+import static com.facebook.presto.expressiontranslationtoolkit.ScalarFromAnnotationsParser.removeTypeParameters;
+import static com.facebook.presto.spi.type.RealType.REAL;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+
+public abstract class AbstractFunctionTranslator
+        implements FunctionTranslator
+{
+    private final Map<FunctionMetadata, MethodHandle> translators;
+    private final Set<TypeSignature> constantTypes;
+
+    public AbstractFunctionTranslator(List<Class<?>> functions, List<Type> constants)
+    {
+        this.translators = registerFunctions(functions);
+        this.constantTypes = registerConstantTypes(constants);
+    }
+
+    public TargetExpression translate(ConstantExpression expression)
+    {
+        TypeSignature typeSignature = removeTypeParameters(expression.getType().getTypeSignature());
+
+        if (!constantTypes.contains(typeSignature)) {
+            return TargetExpression.empty();
+        }
+
+        Object value = expression.getValue();
+        if (typeSignature.equals(removeTypeParameters(VARCHAR.getTypeSignature()))) {
+            return tanslateVarchar(expression);
+        }
+
+        if (typeSignature.equals(removeTypeParameters(REAL.getTypeSignature()))) {
+            return tanslateReal(expression);
+        }
+
+        return tanslateConstant(expression);
+    }
+
+    public TargetExpression translate(FunctionMetadata functionSignature, List<TargetExpression> arguments)
+    {
+        FunctionMetadata functionMetadata = removeTypeParameters(functionSignature);
+        MethodHandle methodHandle = translators.get(functionMetadata);
+
+        if (methodHandle == null) {
+            return TargetExpression.empty();
+        }
+
+        try {
+            return (TargetExpression) methodHandle.invokeWithArguments(arguments);
+        }
+        catch (RuntimeException e) {
+            throw e;
+        }
+        catch (Throwable t) {
+            if (t instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            throw new RuntimeException(t);
+        }
+    }
+
+    private Map<FunctionMetadata, MethodHandle> registerFunctions(List<Class<?>> classes)
+    {
+        ImmutableMap.Builder<FunctionMetadata, MethodHandle> functions = ImmutableMap.builder();
+        classes.forEach(clazz -> functions.putAll(parseFunctionDefinitions(clazz)));
+        return functions.build();
+    }
+
+    private Set<TypeSignature> registerConstantTypes(List<Type> classes)
+    {
+        ImmutableSet.Builder<TypeSignature> constantTypes = ImmutableSet.builder();
+        classes.forEach(clazz -> constantTypes.add(removeTypeParameters(clazz.getTypeSignature())));
+        return constantTypes.build();
+    }
+}

--- a/presto-expression-translation-toolkit/src/main/java/com/facebook/presto/expressiontranslationtoolkit/translator/FunctionTranslator.java
+++ b/presto-expression-translation-toolkit/src/main/java/com/facebook/presto/expressiontranslationtoolkit/translator/FunctionTranslator.java
@@ -1,0 +1,20 @@
+package com.facebook.presto.expressiontranslationtoolkit.translator;
+
+import com.facebook.presto.expressiontranslationtoolkit.TargetExpression;
+import com.facebook.presto.spi.function.FunctionMetadata;
+import com.facebook.presto.spi.relation.ConstantExpression;
+
+import java.util.List;
+
+public interface FunctionTranslator
+{
+    TargetExpression tanslateVarchar(ConstantExpression expression);
+
+    TargetExpression tanslateReal(ConstantExpression expression);
+
+    TargetExpression tanslateConstant(ConstantExpression expression);
+
+    TargetExpression translate(ConstantExpression expression);
+
+    TargetExpression translate(FunctionMetadata functionSignature, List<TargetExpression> arguments);
+}

--- a/presto-expression-translation-toolkit/src/main/java/com/facebook/presto/expressiontranslationtoolkit/translator/RowExpressionTranslator.java
+++ b/presto-expression-translation-toolkit/src/main/java/com/facebook/presto/expressiontranslationtoolkit/translator/RowExpressionTranslator.java
@@ -1,0 +1,184 @@
+package com.facebook.presto.expressiontranslationtoolkit.translator;
+
+import com.facebook.presto.expressiontranslationtoolkit.TargetExpression;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.function.FunctionMetadata;
+import com.facebook.presto.spi.function.FunctionMetadataManager;
+import com.facebook.presto.spi.function.StandardFunctionResolution;
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.DeterminismEvaluator;
+import com.facebook.presto.spi.relation.InputReferenceExpression;
+import com.facebook.presto.spi.relation.LambdaDefinitionExpression;
+import com.facebook.presto.spi.relation.LogicalRowExpressions;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.RowExpressionVisitor;
+import com.facebook.presto.spi.relation.SpecialFormExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.google.common.collect.ImmutableList;
+
+import java.util.Collection;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+public class RowExpressionTranslator
+{
+//    public static final int MAX_CLAUSES_TO_PUSHDOWN = 10;
+//    public static final int MAX_TERMS_PER_CLAUSE_TO_PUSHDOWN = 6;
+
+    private final Visitor visitor;
+    private final LogicalRowExpressions logicalRowExpressions;
+
+    public RowExpressionTranslator(
+            FunctionTranslator functionTranslator, FunctionMetadataManager functionMetadataManager, StandardFunctionResolution functionResolution, DeterminismEvaluator determinismEvaluator)
+    {
+        this.visitor = new Visitor(functionTranslator, functionMetadataManager);
+        this.logicalRowExpressions = new LogicalRowExpressions(determinismEvaluator, functionResolution, functionMetadataManager);
+    }
+
+    public TargetExpression translate(
+            RowExpression expression,
+            Map<VariableReferenceExpression, ColumnHandle> assignments)
+    {
+        return logicalRowExpressions.convertToConjunctiveNormalForm(expression).accept(visitor, assignments);
+    }
+
+    private static class Visitor
+            implements RowExpressionVisitor<TargetExpression, Map<VariableReferenceExpression, ColumnHandle>>
+    {
+        private final FunctionTranslator functionTranslator;
+        private final FunctionMetadataManager functionMetadataManager;
+
+        private Visitor(FunctionTranslator functionTranslator, FunctionMetadataManager functionMetadataManager)
+        {
+            this.functionTranslator = requireNonNull(functionTranslator);
+            this.functionMetadataManager = requireNonNull(functionMetadataManager);
+        }
+
+        @Override
+        public TargetExpression visitInputReference(InputReferenceExpression node, Map<VariableReferenceExpression, ColumnHandle> context)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public TargetExpression visitConstant(ConstantExpression node, Map<VariableReferenceExpression, ColumnHandle> context)
+        {
+            return functionTranslator.translate(node);
+        }
+
+        @Override
+        public TargetExpression visitVariableReference(VariableReferenceExpression node, Map<VariableReferenceExpression, ColumnHandle> context)
+        {
+//            CubrickColumnHandle cubrickColumnHandle = (CubrickColumnHandle) context.get(node);
+//
+//            checkArgument(cubrickColumnHandle != null, "cubrickColumnHandle is null");
+//            return new TargetExpression(PUSHABLE, Optional.of("`" + cubrickColumnHandle.getColumnName() + "`"));
+            return null;
+        }
+
+        @Override
+        public TargetExpression visitCall(CallExpression node, Map<VariableReferenceExpression, ColumnHandle> context)
+        {
+            FunctionMetadata metadata = functionMetadataManager.getFunctionMetadata(node.getFunctionHandle());
+            ImmutableList.Builder<TargetExpression> argumentSqls = ImmutableList.builder();
+
+            for (RowExpression expression : node.getArguments()) {
+                TargetExpression sql = expression.accept(this, context);
+                argumentSqls.add(sql);
+            }
+
+            return functionTranslator.translate(metadata, argumentSqls.build());
+        }
+
+        @Override
+        public TargetExpression visitLambda(LambdaDefinitionExpression node, Map<VariableReferenceExpression, ColumnHandle> context)
+        {
+            return TargetExpression.empty();
+        }
+
+        /**
+         * Refer to class TargetExpression.PushdownState for push definition
+         * *A AND B:*
+         * - if both A and B are fully pushable, A AND B is *fully pushable*
+         * - if neither A nor B is pushable, A AND B is *not pushable*
+         * <p>
+         * *A OR B:*
+         * - if both A and B are fully pushable, A OR B is *fully pushable* (same constraint)
+         * - w.l.o.g, if A is *not pushable*, no matter B is *pushable (fully or partially) or not*
+         * B can not be pushed down, A OR B *not pushable* (harden the constraint)
+         */
+        @Override
+        public TargetExpression visitSpecialForm(SpecialFormExpression node, Map<VariableReferenceExpression, ColumnHandle> context)
+        {
+//            // TODO: We only support AND OR pushdown for now, but we may support other special form in the future.
+//            if (node.getForm() == AND || node.getForm() == OR) {
+//                // Expression should be in CNF form now - meaning all ANDs are brought top top and ORs are at the bottom
+//                if (node.getForm() == AND) {
+//                    // Collect all clauses. Recursively call on each term in the clause and filter for valid pushable
+//                    // ones. Enforce the MAX NUMBER OF CLAUSES constraint and combine to a single Cubrick SQL statement
+//                    List<RowExpression> clauses = ImmutableList.copyOf(extractConjuncts(node));
+//                    List<TargetExpression> pushdownCubrickSQLs = clauses
+//                            .stream()
+//                            .map(expression -> expression.accept(this, context))
+//                            .filter(TargetExpression::isPushable)
+//                            .collect(toImmutableList());
+//
+//                    if (!pushdownCubrickSQLs.isTranslatedExpressionPresent()) {
+//                        return combinePredicates(AND, pushdownCubrickSQLs.subList(0, Math.min(pushdownCubrickSQLs.size(), MAX_CLAUSES_TO_PUSHDOWN)));
+//                    }
+//                }
+//                else {
+//                    // Collect all terms. Recursively call on each term in the clause. If they are all pushable and
+//                    // honour the MAX TERMS PER CLAUSE constraint then combine to a single Cubrick SQL statement
+//                    List<RowExpression> terms = ImmutableList.copyOf(extractDisjuncts(node));
+//                    List<TargetExpression> pushdownCubrickSQLs = terms
+//                            .stream()
+//                            .map(expression -> expression.accept(this, context))
+//                            .filter(TargetExpression::isPushable)
+//                            .collect(toImmutableList());
+//
+//                    if (!pushdownCubrickSQLs.isTranslatedExpressionPresent()
+//                            && pushdownCubrickSQLs.size() == terms.size()
+//                            && pushdownCubrickSQLs.size() <= MAX_TERMS_PER_CLAUSE_TO_PUSHDOWN) {
+//                        return combinePredicates(OR, pushdownCubrickSQLs);
+//                    }
+//                }
+//            }
+//            return notPushable();
+            return null;
+        }
+
+        /**
+         * Takes pushable SQL statements collection and joins them with AND or OR.
+         * @param form AND or OR
+         * @param collection of pushable cubrick sql statements we must combine using `form`
+         * @return new pushable AND or OR expression as cubrick sql
+         */
+        private TargetExpression combinePredicates(
+                SpecialFormExpression.Form form,
+                Collection<TargetExpression> collection)
+        {
+//            if (form != AND && form != OR) {
+//                throw new IllegalArgumentException(String.format("Form must be AND or OR. Found: %s", form));
+//            }
+//
+//            if (collection.size() == 0) {
+//                throw new IllegalArgumentException("expressions passed in must have size >= 1");
+//            }
+//
+//            return collection
+//                    .stream()
+//                    .reduce((cSql1, cSql2) -> new TargetExpression(
+//                            PUSHABLE,
+//                            Optional.of(
+//                                    format("(%s) %s (%s)",
+//                                            cSql1.getCubrickSQL(),
+//                                            form == AND ? "AND" : "OR",
+//                                            cSql2.getCubrickSQL()))))
+//                    .get();
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Temp PR for demonstrating WIP translator interface.

Here is how the user will use this API:
```
FunctionTranslator functionTranslator = new AbstractFunctionTranslator(
    ImmutableList.of( // function translation classes
         BigintOperators.class,
         ...),
     ImmutableList.of( // constant translation types
         BigintType.BIGINT,
         ....))
{
    @Override
    public TargetExpression tanslateVarchar(ConstantExpression expression)
    {
        return null;
    }

    @Override
    public TargetExpression tanslateReal(ConstantExpression expression)
    {
        return null;
    }

    @Override
    public TargetExpression tanslateConstant(ConstantExpression expression)
    {
        return null;
    }
};

// in the user's ComputePushdown class (i.e. JdbcComputePushdown)
this.rowExpressionTranslator = new RowExpressionTranslator(functionTranslator, ...)
```